### PR TITLE
I tried to make it into a gem ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 data/
 output/
-*.csv*.gem
+*.csv
+*.gem

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 data/
 output/
-*.csv
+*.csv*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in access_checker.gemspec
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,1 @@
+require "bundler/gem_tasks"

--- a/access_checker.gemspec
+++ b/access_checker.gemspec
@@ -1,0 +1,28 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'access_checker/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = "access_checker"
+  spec.version       = AccessChecker::VERSION
+  spec.authors       = ["Kristina Spurgin"]
+  spec.email         = ["TODO: ADD EMAIL"]
+  spec.summary       = %q{A script to check for full-text access to e-resource titles.}
+  spec.description   = %q{A simple JRuby script to check for full-text access to e-resource titles. Plain old URL/link checking won't alert you if one of your ebook links points to a valid HTML page reading "NO ACCESS." This script will.}
+  spec.homepage      = ""
+  spec.license       = "GNU General Public License v3 or later"
+
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.platform = 'java'
+
+  spec.add_runtime_dependency 'celerity', '~> 0.9.2'
+  spec.add_runtime_dependency 'highline', '~> 1.6.21'
+
+  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "rake"
+end

--- a/bin/access_checker
+++ b/bin/access_checker
@@ -1,3 +1,4 @@
+#!/usr/bin/env jruby
 # Tested in JRuby 1.7.3
 # Written by Kristina Spurgin
 # Last updated: 20130412
@@ -19,6 +20,8 @@ require 'celerity'
 require 'csv'
 require 'highline/import'
 require 'open-uri'
+
+require 'access_checker'
 
   puts "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
   puts "What platform/package are you access checking?"

--- a/lib/access_checker.rb
+++ b/lib/access_checker.rb
@@ -1,0 +1,5 @@
+require "access_checker/version"
+
+module AccessChecker
+  # Your code goes here...
+end

--- a/lib/access_checker/version.rb
+++ b/lib/access_checker/version.rb
@@ -1,0 +1,3 @@
+module AccessChecker
+  VERSION = "0.0.1"
+end


### PR DESCRIPTION
Hi Kristina,

I read your article in Code4Lib Journal today and I think you have a great idea. I wanted to tinker a bit with the script, and in that process I will probably break it up a bit into smaller pieces. To enable that I started by giving it a common gem structure, and I thought that _maybe_ you would like to pull that initial change back in?

The code isn't changed at all at this point, except for one small adjustment. The script now lives in bin/access_checker (no .rb extension) and has a "shebang-line" of `#!/usr/bin/env ruby`. This makes it easy to use with rvm or any such tools. (You can still run it with "jruby -S bin/access_checker".)

I haven't released it as a gem, that must be up to you if you want to. And there is no e-mail in the gem spec, I didn't know yours or if you would like to have it public.

Please feel free to ignore this pull request - it is by no means necessary and doesn't in any way enhance your script. It only enables it to be installed with `gem install access_checker`, should you choose to publish it.
