### PR TITLE
Make script executable via shebang

### DIFF
--- a/access_checker.rb
+++ b/access_checker.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 # Tested in JRuby 1.7.3
 # Written by Kristina Spurgin
 # Last updated: 2016-04-15


### PR DESCRIPTION
The addition of a header shebang as well as changing the file permissions allow calling upon this script directly on Linux.

I could update the `README.md`, but I'm not sure the added complexity would be beneficial to this script's target audience. Your call.